### PR TITLE
Add Fontawesome icons for ETS, EVP & TFP

### DIFF
--- a/Scripts/enablers-table.js
+++ b/Scripts/enablers-table.js
@@ -241,7 +241,7 @@ const populateResourcesCell =function populateResourcesCell(row, config) {
       iconImg = 'fab fa-github'
     } else if (resourceType === 'ETS') {
       url = resource.url
-      iconImg = 'as fa-flask'
+      iconImg = 'fas fa-flask'
     } else if (resourceType === 'EVP') {
       url = resource.url
       iconImg = 'fas fa-cubes'


### PR DESCRIPTION
@rubystream I have added three new icons to represent "ETS, EVP and TFP" resources.
I don't think we need to change any other file but ... I prefer that you cross-check. The changes run ok locally. 