### PR TITLE
[ADMIN] Remove from enabler.json

### DIFF
--- a/enablers.json
+++ b/enablers.json
@@ -1742,12 +1742,6 @@
         ],
         "versions": [
           {
-            "name": "V1_1_2-20030612-A",
-            "status": "Approved",
-            "version": "V1.1.2",
-            "date": "2003-06-12"
-          },
-          {
             "name": "V1_1_2-20040711-A",
             "status": "Approved",
             "version": "V1.1.2",


### PR DESCRIPTION
@jmudge there were still a few duplicated releases.
I am suggesting removing them from the enablers.json file as in all the cases. The version is the same but the date and the documents on a later release are different. So we will keep the latest one.