### PR TITLE
New index page shouldn't display entry for Presence Simple V1.0

### DIFF
--- a/enablers.json
+++ b/enablers.json
@@ -9525,7 +9525,8 @@
             "name": "V1_0-20050125-C",
             "status": "Candidate",
             "version": "V1.0",
-            "date": "2005-01-25"
+            "date": "2005-01-25",
+            "display": false
           },
           {
             "name": "V2_1-20051122-C",


### PR DESCRIPTION
Also don't display entry in new index page for Push V1.0 as it is out of date.

Resolves issue https://github.com/OpenMobileAlliance/technical.openmobilealliance.org/issues/90