### PR TITLE
Add Approved LwM2M ETS to publications

### DIFF
--- a/publications.json
+++ b/publications.json
@@ -14861,7 +14861,7 @@
     "fileName": "OMA-ETS-LightweightM2M-V1_0_1-20170926-A.pdf",
     "docType": "Enabler Test Specification",
     "url": "https://www.openmobilealliance.org/release/LightweightM2M/ETS/OMA-ETS-LightweightM2M-V1_0_1-20170926-A.pdf",
-    "description": "The purpose of this document is to provide test cases for LightweightM2M Enabler Release V1.0. The implementation of some features is optional for the Clients and/or the Servers in the LightweightM2M Enabler. The tests associated with these optional features are marked as "(Includes Optional Features)" in the test specification",
+    "description": "The purpose of this document is to provide test cases for LightweightM2M Enabler Release V1.0. The implementation of some features is optional for the Clients and/or the Servers in the LightweightM2M Enabler. The tests associated with these optional features are marked as (Includes Optional Features) in the test specification",
     "contentMediaType": "application/pdf"
   },
   {

--- a/publications.json
+++ b/publications.json
@@ -14853,6 +14853,19 @@
   },
   {
     "organization": "https://technical.openmobilealliance.org/organization-info.json",
+    "enablerName": "OMA Enabler Test Specification for LightweightM2M (LwM2M)",
+    "enablerAbbreviation": "LightweightM2M",
+    "status": "Approved",
+    "version": "V1.0.1",
+    "releaseDate": "2017-09-26",
+    "fileName": "OMA-ETS-LightweightM2M-V1_0_1-20170926-A.pdf",
+    "docType": "Enabler Test Specification",
+    "url": "https://www.openmobilealliance.org/release/LightweightM2M/ETS/OMA-ETS-LightweightM2M-V1_0_1-20170926-A.pdf",
+    "description": "The purpose of this document is to provide test cases for LightweightM2M Enabler Release V1.0. The implementation of some features is optional for the Clients and/or the Servers in the LightweightM2M Enabler. The tests associated with these optional features are marked as "(Includes Optional Features)" in the test specification",
+    "contentMediaType": "application/pdf"
+  },
+  {
+    "organization": "https://technical.openmobilealliance.org/organization-info.json",
     "enablerName": "OMA LightweightM2M (LwM2M)",
     "enablerAbbreviation": "LightweightM2M",
     "status": "Approved",


### PR DESCRIPTION
@gocadimic, I have added the approved ETS v1.0.1 to the `publications' file.

Please add the following ETSs as per the example: (add them below the example)
* ETS Location: https://openmobilealliance.org/release/LightweightM2M/ETS/
* ETS LwM2M v1.0.2, [OMA-ETS-LightweightM2M-V1_0_2-20180815-A.zip](https://openmobilealliance.org/release/LightweightM2M/ETS/OMA-ETS-LightweightM2M-V1_0_2-20180815-A.zip)
* ETS LwM2M v1.1, [OMA-ETS-LightweightM2M-V1_1-20190912-D.pdf](https://openmobilealliance.org/release/LightweightM2M/ETS/OMA-ETS-LightweightM2M-V1_1-20190912-D.pdf), and
* ETS LwM2M v1.2, [OMA-ETS-LightweightM2M_INT-V1_2-20231003-A.pdf](https://openmobilealliance.org/release/LightweightM2M/ETS/OMA-ETS-LightweightM2M_INT-V1_2-20231003-A.pdf)