### PR TITLE
Bulk object reservation 35450 to 35499 for Grinn sp. z.o.o

### DIFF
--- a/OMNA/LwM2M/reserved.xml
+++ b/OMNA/LwM2M/reserved.xml
@@ -294,4 +294,9 @@
         <ObjectIDEndRange>35449</ObjectIDEndRange>
         <Company>Watts A/S</Company>
     </Item>
+    <Item>
+        <ObjectIDStartRange>35450</ObjectIDStartRange>
+        <ObjectIDEndRange>35499</ObjectIDEndRange>
+        <Company>Grinn sp. z.o.o</Company>
+    </Item>
 </ReservedObjects>


### PR DESCRIPTION
A new bulk object reservation is available for 35400 to 35449 for Grinn SP as requested per https://helpdesk.openmobilealliance.org/browse/OPEN-8060.
A previous reservation for the same company was assigned to Watts A/S, see PR #209.
