### PR TITLE
[ADMIN] bulk reservation objects 35750-35799 range for Atlas Copco

### DIFF
--- a/OMNA/LwM2M/reserved.xml
+++ b/OMNA/LwM2M/reserved.xml
@@ -324,4 +324,9 @@
         <ObjectIDEndRange>35749</ObjectIDEndRange>
         <Company>Moxa Inc.</Company>
     </Item>
+     <Item>
+        <ObjectIDStartRange>357500</ObjectIDStartRange>
+        <ObjectIDEndRange>35799</ObjectIDEndRange>
+        <Company>Atlas Copco</Company>
+    </Item>
 </ReservedObjects>


### PR DESCRIPTION
A new bulk object reservation for Atlas Copco is available for a 35750 to 35799 range, as requested per the [Helpdesk issue 8105](https://helpdesk.openmobilealliance.org/browse/OPEN-8105).
